### PR TITLE
Updates workflow file for docs build to use `DEPLOY_KEY` instead of legacy `DOCS_DEPLOY_KEY`

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -13,5 +13,4 @@ jobs:
       - name: Build Docs
         uses: laminas/documentation-theme/github-actions/docs@master
         env:
-          "DOCS_DEPLOY_KEY": ${{ secrets.DOCS_DEPLOY_KEY }}
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reference: https://github.com/laminas/documentation-theme/tree/master/github-actions/docs#environment