### PR TITLE
Adds missing configuration for project to MkDocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,3 +7,5 @@ nav:
 site_name: 'laminas-servicemanager-migration'
 site_description: 'Migrate your code to laminas-servicemanager 4.x compatibility utilizing Rector rules.'
 repo_url: 'https://github.com/laminas/laminas-servicemanager-migration'
+extra:
+    project: Components


### PR DESCRIPTION
```bash
Traceback (most recent call last):
  File "/github/workspace/documentation-theme/update_mkdocs_yml.py", line 56, in <module>
    mkdocs["extra"]["repo_name"] = mkdocs["repo_url"].replace("https://github.com/", "")
KeyError: 'extra'
```

https://github.com/laminas/laminas-servicemanager-migration/actions/runs/3747785291/jobs/6364385361#step:3:34