### PR TITLE
Fix deprecated dynamic pull BetterNodeFinder from AbstractRector

### DIFF
--- a/src/Rector/Class_/ImplementsFactoryInterfaceToPsrFactoryRector.php
+++ b/src/Rector/Class_/ImplementsFactoryInterfaceToPsrFactoryRector.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\Stmt\UseUse;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Naming\Naming\UseImportsResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -26,7 +27,8 @@ final class ImplementsFactoryInterfaceToPsrFactoryRector extends AbstractRector
     private const FACTORY_INTERFACE = FactoryInterface::class;
 
     public function __construct(
-        private UseImportsResolver $useImportsResolver
+        private UseImportsResolver $useImportsResolver,
+        private BetterNodeFinder $betterNodeFinder
     ) {
     }
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Fix error notice:

```
➜  laminas-servicemanager-migration git:(1.44.x) vendor/bin/phpunit 
PHPUnit 9.6.13 by Sebastian Bergmann and contributors.

..Get betterNodeFinder property from AbstractRector on Laminas\ServiceManager\Migration\Rector\Class_\ImplementsFactoryInterfaceToPsrFactoryRector is deprecated, inject via __construct() instead
..Get betterNodeFinder property from AbstractRector on Laminas\ServiceManager\Migration\Rector\Class_\ImplementsFactoryInterfaceToPsrFactoryRector is deprecated, inject via __construct() instead
.Get betterNodeFinder property from AbstractRector on Laminas\ServiceManager\Migration\Rector\Class_\ImplementsFactoryInterfaceToPsrFactoryRector is deprecated, inject via __construct() instead
..............                                               19 / 19 (100%)

Time: 00:00.827, Memory: 68.00 MB

OK (19 tests, 34 assertions)
```

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
